### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ linked = []
 string = ["vec"]
 
 [dependencies]
-spin = { version = "0.9", default-features = false, features = ["spin_mutex", "mutex"] }
+spin = { version = "0.9.8", default-features = false, features = ["spin_mutex", "mutex"] }
 
 [dev-dependencies]
-spin = { version = "0.9", default-features = false, features = ["rwlock"] }
+spin = { version = "0.9.8", default-features = false, features = ["rwlock"] }


### PR DESCRIPTION
Updates dependency to the patch version of 0.9.8

[Advisory](https://rustsec.org/advisories/RUSTSEC-2023-0031.html)